### PR TITLE
fix(docs): 移除导航栏的毛玻璃效果

### DIFF
--- a/apps/docs/.vitepress/theme/custom.css
+++ b/apps/docs/.vitepress/theme/custom.css
@@ -106,8 +106,6 @@
 
 /* 给导航栏添加毛玻璃效果 */
 .VPNav {
-  backdrop-filter: blur(8px) !important;
-  -webkit-backdrop-filter: blur(8px) !important;
   background: rgba(var(--vp-c-bg-rgb), 0.85) !important;
   border-bottom: 1px solid rgba(var(--vp-c-divider-rgb), 0.1) !important;
 }


### PR DESCRIPTION
- 删除了 VPNav 类中的Backdrop-Filter属性
- backdrop-filter 属性会创建一个新的层叠上下文影响移动端的导航栏展示