### PR TITLE
build: 添加 playground 项目脚本并指定包管理器版本

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,14 @@
   "version": "1.0.0",
   "description": "火山知识库",
   "private": true,
+  "packageManager": "pnpm@8.15.0",
   "scripts": {
     "docs:dev": "pnpm --filter docs dev",
     "docs:build": "pnpm --filter docs build",
-    "docs:preview": "pnpm --filter docs preview"
+    "docs:preview": "pnpm --filter docs preview",
+    "playground:dev": "pnpm --filter playground dev",
+    "playground:build": "pnpm --filter playground build",
+    "playground:start": "pnpm --filter playground start"
   },
   "devDependencies": {
     "typescript": "^5.0.2"


### PR DESCRIPTION
- 在 package.json 中添加 "packageManager" 字段，指定 pnpm版本为 8.15.0
- 新增 playground项目的开发、构建和启动脚本